### PR TITLE
Google Charts API works with serverside

### DIFF
--- a/templates/pages/index.html
+++ b/templates/pages/index.html
@@ -94,9 +94,13 @@
       }
 
       async function getWeeklyData(){
-        const url = 'https://run.mocky.io/v3/6184f23f-8dd1-49f0-8e32-809a797f1aa0';
-        const response = await fetch(url);
+        //const url = 'https://run.mocky.io/v3/6184f23f-8dd1-49f0-8e32-809a797f1aa0';
+        const url = 'https://home-run.herokuapp.com/calculations';
+        //const response = await fetch(url);
+        const response = await fetch(url, {method: 'POST'});
+        console.log(response);
         const jsonResponse = await response.json();
+        console.log(jsonResponse);
         return jsonResponse;
       }
     </script>


### PR DESCRIPTION
URL was replaced with the actual serverside script
and now loads the graph with the proper data.